### PR TITLE
set column names for empty dataframe properly

### DIFF
--- a/R/Quandldatatable.R
+++ b/R/Quandldatatable.R
@@ -47,7 +47,23 @@ Quandl.datatable <- function(code, paginate=FALSE, ...) {
                   "https://github.com/quandl/quandl-r/blob/master/README.md#datatables"), call. = FALSE)
   }
 
+  df <- quandl.datatable.set_df_columns(df, columns)
+
+  return(df)
+}
+
+quandl.datatable.set_df_columns <- function(df, columns) {
+  ncols <- length(columns[,1])
+  # if df is empty create an empty df with ncolumns set
+  # or else we won't be able to set the column names
+  if (nrow(df) <= 0 && ncols > 0) {
+    df <- data.frame(matrix(ncol = ncols, nrow = 0))
+  }
+
+  # set column names
   names(df) <- columns[,1]
+
+  # set column types
   df <- quandl.datatable.convert_df_columns(df, columns[,2])
 
   return(df)
@@ -63,6 +79,8 @@ quandl.datatable.convert_df_columns <- function(df, column_types) {
       df[,i] <- as.numeric(df[,i])
     } else if (grepl("^date", column_types[i])) {
       df[,i] <- as.Date(df[,i])
+    } else {
+      df[,i] <- as.character(df[,i])
     }
   }
   return(df)

--- a/tests/testthat/test-datatable-helper.r
+++ b/tests/testthat/test-datatable-helper.r
@@ -36,3 +36,16 @@ mock_datatable_data <- function(cursor_id = 'null') {
   mock_data <- gsub("\"#cursor_id\"", cursor_id, mock_data)
   return(mock_data)
 }
+
+mock_empty_datatable_data <- function() {
+  mock_data <- "{\"datatable\":
+  {\"data\": [],
+  \"columns\":[{\"name\":\"ticker\",\"type\":\"String\"},
+  {\"name\":\"oper_income\",\"type\":\"BigDecimal(12,4)\"},
+  {\"name\":\"comm_share_holder\",\"type\":\"Integer\"},
+  {\"name\":\"per_end_date\",\"type\":\"Date\"}]},
+  \"meta\":{\"next_cursor_id\": null
+  }
+  }"
+  return(mock_data)
+}

--- a/tests/testthat/test-datatable.r
+++ b/tests/testthat/test-datatable.r
@@ -68,7 +68,7 @@ with_mock(
     data <- Quandl.datatable('ZACKS/FC')
     expect_equal(names(data), c("ticker", "oper_income", "comm_share_holder", "per_end_date"))
   }),
-  test_that("response data columns are convereted to proper data types", {
+  test_that("response data columns are converted to proper data types", {
     data <- Quandl.datatable('ZACKS/FC')
     expect_is(data[,1], "character")
     expect_is(data[,2], "numeric")
@@ -88,6 +88,24 @@ with_mock(
       paste("This call returns a larger amount of data than Quandl.datatable() allows.",
             "Please view our documentation on developer methods to request more data.",
             "https://github.com/quandl/quandl-r/blob/master/README.md#datatables"), fixed = TRUE)
+  })
+)
+
+context("Quandl.datatable() empty data response")
+with_mock(
+  `httr::VERB` = function(http, url, config, body, query) {
+    mock_response(content = mock_empty_datatable_data())
+  },
+  `httr::content` = function(response, as="text") {
+    response$content
+  },
+  test_that("empty response data columns are converted to proper data types", {
+    data <- Quandl.datatable('ZACKS/FC')
+    expect_equal(nrow(data), 0)
+    expect_is(data[,1], "character")
+    expect_is(data[,2], "numeric")
+    expect_is(data[,3], "numeric")
+    expect_is(data[,4], "Date")
   })
 )
 


### PR DESCRIPTION
Tracker Ticket: 
https://quandl.atlassian.net/browse/AP-1780

## Description:  
* R-package was erroring out because if the data returned is empty form quandl response, it will have 0 columns and so we cannot rename the columns
* Fix this crash by setting an empty data frame ourselves, one that is initialized with x columns with no data
* Set the names of the columns properly for empty data response
* Default column type is now "character"

## Note to the reviewer:



## Note to QA:
* Ensure column names are set properly for data response (when there is no data in response, and when there is data)
 * no data example call: `Quandl.datatable('ZACKS/FC', qopts.per_page=1, per_end_date='2016-10-10')`
* Ensure column types are set properly in each scenario: you can verify the column types by doing this on the data frame: `sapply(df, class)` where df is obtained by `df <- Quandl.datatable(...)`
* R types: character, date, numeric
* https://www.quandl.com/api/v3/datatables/ZACKS/FC?<> BigDecimal, String, Integer, Dates




## Dependency(if any): 



## Screenshot(if any): 