### PR TITLE
CP-8963/Datetimes for point in time

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,19 @@ PointInTime works similarly to datatables but filtering the data based on dates.
 Quandl.pit.asofdate('DATABASE/CODE', '2020-01-01')
 ```
 
+## Date Format
+
+Dates passed to `Quandl.pit` calls must be a valid `ISO 8601` datetime. For example, the follow values are valid dates:
+
+- `2021-03-02`
+- `2021-03-02T13:45:00`
+- `2021-03-02T12:55:00-05:00`
+
+While the following are invalid:
+
+- `2021-03-02 13:45:00` (missing `T` between date and time)
+- `March 2nd, 2021` (not `ISO 8601` compliant)
+
 ### Available functions
 
 | Interval | Explanation | Required params | Example |

--- a/tests/testthat/test-pointintime.r
+++ b/tests/testthat/test-pointintime.r
@@ -7,7 +7,7 @@ context("Getting PIT Datatable data")
 context("Quandl.pit.fromto() call")
 with_mock(
   `httr::VERB` = function(http, url, config, body, query) {
-    test_that("correct arguments are passed in", {
+    test_that("correct arguments are passed in when dates used", {
       expect_equal(http, "GET")
       expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/from/2020-01-01/to/2020-01-03")
       expect_null(body)
@@ -20,11 +20,27 @@ with_mock(
   },
   Quandl.pit.fromto("RSM/MSB", "2020-01-01", "2020-01-03")
 )
+with_mock(
+  `httr::VERB` = function(http, url, config, body, query) {
+    test_that("correct arguments are passed in when datetimes used", {
+      expect_equal(http, "GET")
+      expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/from/2020-01-01T12:00/to/2020-01-03T14:00")
+      expect_null(body)
+      expect_equal(query, list())
+    })
+    mock_response(content = mock_datatable_data())
+  },
+  `httr::content` = function(response, as="text") {
+    response$content
+  },
+  Quandl.pit.fromto("RSM/MSB", "2020-01-01T12:00", "2020-01-03T14:00")
+)
+
 
 context("Quandl.pit.between() call")
 with_mock(
   `httr::VERB` = function(http, url, config, body, query) {
-    test_that("correct arguments are passed in", {
+    test_that("correct arguments are passed in when dates used", {
       expect_equal(http, "GET")
       expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/between/2020-01-01/2020-01-03")
       expect_null(body)
@@ -37,11 +53,26 @@ with_mock(
   },
   Quandl.pit.between("RSM/MSB", "2020-01-01", "2020-01-03")
 )
+with_mock(
+  `httr::VERB` = function(http, url, config, body, query) {
+    test_that("correct arguments are passed when datetimes used", {
+      expect_equal(http, "GET")
+      expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/between/2020-01-01T12:00/2020-01-03T14:00")
+      expect_null(body)
+      expect_equal(query, list())
+    })
+    mock_response(content = mock_datatable_data())
+  },
+  `httr::content` = function(response, as="text") {
+    response$content
+  },
+  Quandl.pit.between("RSM/MSB", "2020-01-01T12:00", "2020-01-03T14:00")
+)
 
 context("Quandl.pit.asofdate() call")
 with_mock(
   `httr::VERB` = function(http, url, config, body, query) {
-    test_that("correct arguments are passed in", {
+    test_that("correct arguments are passed in when dates used", {
       expect_equal(http, "GET")
       expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/asofdate/2020-01-01")
       expect_null(body)
@@ -54,11 +85,26 @@ with_mock(
   },
   Quandl.pit.asofdate("RSM/MSB", "2020-01-01")
 )
+with_mock(
+  `httr::VERB` = function(http, url, config, body, query) {
+    test_that("correct arguments are passed in when datetimes used", {
+      expect_equal(http, "GET")
+      expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/asofdate/2020-01-01T12:00")
+      expect_null(body)
+      expect_equal(query, list())
+    })
+    mock_response(content = mock_datatable_data())
+  },
+  `httr::content` = function(response, as="text") {
+    response$content
+  },
+  Quandl.pit.asofdate("RSM/MSB", "2020-01-01T12:00")
+)
 
 context("Quandl.pit.fromto() call with options")
 with_mock(
   `httr::VERB` = function(http, url, config, body, query) {
-    test_that("correct arguments are passed in", {
+    test_that("correct arguments are passed in when dates used", {
       expect_equal(http, "GET")
       expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/from/2020-01-01/to/2020-01-03")
       expect_null(body)
@@ -73,6 +119,25 @@ with_mock(
   },
   Quandl.pit.fromto("RSM/MSB", "2020-01-01", "2020-01-03", ticker=c('AAPL', 'MSFT'),
                                qopts.columns=c('ticker','per_end_date','tot_revnu'),
+                    paginate=FALSE)
+)
+with_mock(
+  `httr::VERB` = function(http, url, config, body, query) {
+    test_that("correct arguments are passed in when datetimes used", {
+      expect_equal(http, "GET")
+      expect_equal(url, "https://www.quandl.com/api/v3/pit/RSM/MSB/from/2020-01-01T12:00/to/2020-01-03T14:00")
+      expect_null(body)
+      expect_equal(query, list('ticker[]'='AAPL', 'ticker[]'='MSFT',
+                               'qopts.columns[]'='ticker', 'qopts.columns[]'='per_end_date',
+                               'qopts.columns[]'='tot_revnu'))
+    })
+    mock_response(content = mock_datatable_data())
+  },
+  `httr::content` = function(response, as="text") {
+    response$content
+  },
+  Quandl.pit.fromto("RSM/MSB", "2020-01-01T12:00", "2020-01-03T14:00", ticker=c('AAPL', 'MSFT'),
+                    qopts.columns=c('ticker','per_end_date','tot_revnu'),
                     paginate=FALSE)
 )
 


### PR DESCRIPTION
https://quandl.atlassian.net/browse/CP-8963

Merely a documentation update as nothing needs to be done from a client perspective to support it sending datetime strings.